### PR TITLE
ordered list and code block adedd

### DIFF
--- a/src/Convert.hs
+++ b/src/Convert.hs
@@ -17,4 +17,9 @@ convertStructure structure =
       
     Markup.Paragraph p ->
       Html.p_ $ Html.txt_ p
-    --TODO Other cases
+      
+    Markup.OrderedList list ->
+      Html.ol_ $ map (Html.p_ . Html.txt_) list
+
+    Markup.CodeBlock list ->
+      Html.code_ (unlines list)


### PR DESCRIPTION
This pull request includes changes to the `convertStructure` function in the `src/Convert.hs` file to handle additional markup cases. The most important changes include adding support for ordered lists and code blocks.

Markup handling improvements:

* [`src/Convert.hs`](diffhunk://#diff-f6934999e2d67ae7caa288a84b000af41d1067c517436f64d3b7f88f48595804L20-R25): Added support for `Markup.OrderedList` by mapping each list item to an HTML paragraph element.
* [`src/Convert.hs`](diffhunk://#diff-f6934999e2d67ae7caa288a84b000af41d1067c517436f64d3b7f88f48595804L20-R25): Added support for `Markup.CodeBlock` by converting the list of code lines into a single HTML code block element.