### PR TITLE
added horizontal line

### DIFF
--- a/Input/default.txt
+++ b/Input/default.txt
@@ -1,5 +1,7 @@
 * Compiling programs with ghc
 
+---
+
 Running ghc invokes the Glasgow Haskell Compiler (GHC),
 and can be used to compile Haskell modules and programs into native
 executables and libraries.

--- a/Output/blog.html
+++ b/Output/blog.html
@@ -31,7 +31,7 @@ pre {
     border : 2px solid lightslategray ;
     border-radius: 5px;
     padding : 5px 5px 5px 5px ;
-}</style></head><body><h1>Compiling programs with ghc</h1><p>Running ghc invokes the Glasgow Haskell Compiler (GHC), and can be used to compile Haskell modules and programs into native executables and libraries.</p><p>Create a new Haskell source file named hello.hs, and write the following code in it:</p><pre>main = putStrLn &quot;Hello, Haskell!&quot;
+}</style></head><body><h1>Compiling programs with ghc</h1><hr><p>Running ghc invokes the Glasgow Haskell Compiler (GHC), and can be used to compile Haskell modules and programs into native executables and libraries.</p><p>Create a new Haskell source file named hello.hs, and write the following code in it:</p><pre>main = putStrLn &quot;Hello, Haskell!&quot;
 </pre><p>Now, we can compile the program by invoking ghc with the file name:</p><pre>-&gt; ghc hello.hs
 [1 of 1] Compiling Main             ( hello.hs, hello.o )
 Linking hello ...

--- a/src/Convert.hs
+++ b/src/Convert.hs
@@ -23,3 +23,6 @@ convertStructure structure =
 
     Markup.CodeBlock list ->
       Html.code_ (unlines list)
+      
+    Markup.HorizontalLine _ -> 
+      Html.hr_

--- a/src/Html.hs
+++ b/src/Html.hs
@@ -8,6 +8,7 @@ module Html
   , txt_
   , html_
   , h1_
+  , hr_
   , p_
   , ul_
   , ol_
@@ -68,6 +69,9 @@ ol_ =
 
 code_ :: String -> Structure
 code_ = Structure . el "pre" . escape
+
+hr_ :: Structure
+hr_ = Structure "<hr>"
 
 instance Semigroup Structure where
   (<>) c1 c2 =

--- a/src/Markup.hs
+++ b/src/Markup.hs
@@ -14,6 +14,7 @@ type Document
 data Structure
   = Heading Natural String
   | Paragraph String
+  | HorizontalLine String
   | UnorderedList [String]
   | OrderedList [String]
   | CodeBlock [String]
@@ -59,6 +60,10 @@ parseLines context txts =
 
         _ ->
           maybe id (:) context (parseLines (Just (CodeBlock [line])) rest)
+    
+    -- Horizontal line case
+    ("---") : rest ->
+      maybe id (:) context (HorizontalLine "_" : parseLines Nothing rest)
     
     -- Paragraph case
     currentLine : rest ->


### PR DESCRIPTION
This pull request includes several changes to add support for horizontal lines in the markup and improve the formatting of the output. The most important changes include modifications to the `Markup` and `Html` modules, as well as updates to the input and output files.

Support for horizontal lines:

* [`src/Markup.hs`](diffhunk://#diff-750d02566fc0dbe7c032fa4801406e7603870d00ab46dba091186c23306d7941R17): Added a new `HorizontalLine` constructor to the `Structure` data type and updated the `parseLines` function to handle horizontal lines. [[1]](diffhunk://#diff-750d02566fc0dbe7c032fa4801406e7603870d00ab46dba091186c23306d7941R17) [[2]](diffhunk://#diff-750d02566fc0dbe7c032fa4801406e7603870d00ab46dba091186c23306d7941R64-R67)
* [`src/Html.hs`](diffhunk://#diff-77f3e5af98b7457d91342dc79deeef1d36ea2a138debf829ad3a731bae95a687R11): Added a new `hr_` function to generate horizontal line HTML elements and updated the module exports to include `hr_`. [[1]](diffhunk://#diff-77f3e5af98b7457d91342dc79deeef1d36ea2a138debf829ad3a731bae95a687R11) [[2]](diffhunk://#diff-77f3e5af98b7457d91342dc79deeef1d36ea2a138debf829ad3a731bae95a687R73-R75)
* [`src/Convert.hs`](diffhunk://#diff-f6934999e2d67ae7caa288a84b000af41d1067c517436f64d3b7f88f48595804R26-R28): Updated the `convertStructure` function to handle the new `HorizontalLine` constructor by generating an `<hr>` HTML element.

Formatting improvements:

* [`Input/default.txt`](diffhunk://#diff-ce22ce117a5120a00aaadd6aef13213c0e3a2e2c8113a7eab8d1b96dbf58f6c1R3-R4): Added a horizontal line to improve the visual separation of sections.
* [`Output/blog.html`](diffhunk://#diff-c6eebd6134faccb682229c887cbffa4cca5cf19c18afd2f3cacba15687f36ae7L34-R34): Added an `<hr>` element to visually separate the header from the content.