### PR TITLE
added h2 and h3 tags

### DIFF
--- a/Input/default.txt
+++ b/Input/default.txt
@@ -1,4 +1,8 @@
-* Compiling programs with ghc
+* H1
+
+** H2
+
+*** H3
 
 ---
 

--- a/Output/blog.html
+++ b/Output/blog.html
@@ -6,6 +6,22 @@
     background-clip: text;
 }
 
+h2 {
+    color: transparent;
+    width: fit-content;
+    background: linear-gradient(to top, rgb(163, 0, 178) , rgb(108, 0, 171));
+    -webkit-background-clip: text;
+    background-clip: text;
+}
+
+h3 {
+    color: transparent;
+    width: fit-content;
+    background: linear-gradient(to top, rgb(163, 0, 178) , rgb(108, 0, 171));
+    -webkit-background-clip: text;
+    background-clip: text;
+}
+
 body {
     background-color: rgb(27, 27, 27);
     padding : 10px 10px 10px 10px
@@ -31,7 +47,7 @@ pre {
     border : 2px solid lightslategray ;
     border-radius: 5px;
     padding : 5px 5px 5px 5px ;
-}</style></head><body><h1>Compiling programs with ghc</h1><hr><p>Running ghc invokes the Glasgow Haskell Compiler (GHC), and can be used to compile Haskell modules and programs into native executables and libraries.</p><p>Create a new Haskell source file named hello.hs, and write the following code in it:</p><pre>main = putStrLn &quot;Hello, Haskell!&quot;
+}</style></head><body><h1>H1</h1><h2>H2</h2><h3>H3</h3><hr><p>Running ghc invokes the Glasgow Haskell Compiler (GHC), and can be used to compile Haskell modules and programs into native executables and libraries.</p><p>Create a new Haskell source file named hello.hs, and write the following code in it:</p><pre>main = putStrLn &quot;Hello, Haskell!&quot;
 </pre><p>Now, we can compile the program by invoking ghc with the file name:</p><pre>-&gt; ghc hello.hs
 [1 of 1] Compiling Main             ( hello.hs, hello.o )
 Linking hello ...

--- a/Styles/defaultStyles.css
+++ b/Styles/defaultStyles.css
@@ -6,6 +6,22 @@ h1 {
     background-clip: text;
 }
 
+h2 {
+    color: transparent;
+    width: fit-content;
+    background: linear-gradient(to top, rgb(163, 0, 178) , rgb(108, 0, 171));
+    -webkit-background-clip: text;
+    background-clip: text;
+}
+
+h3 {
+    color: transparent;
+    width: fit-content;
+    background: linear-gradient(to top, rgb(163, 0, 178) , rgb(108, 0, 171));
+    -webkit-background-clip: text;
+    background-clip: text;
+}
+
 body {
     background-color: rgb(27, 27, 27);
     padding : 10px 10px 10px 10px

--- a/src/Convert.hs
+++ b/src/Convert.hs
@@ -12,6 +12,12 @@ convertStructure structure =
     Markup.Heading 1 txt ->
       Html.h1_ $ Html.txt_ txt
 
+    Markup.Heading 2 txt ->
+      Html.h2_ $ Html.txt_ txt
+
+    Markup.Heading 3 txt ->
+      Html.h3_ $ Html.txt_ txt
+
     Markup.UnorderedList list ->
       Html.ul_ $ map (Html.p_ . Html.txt_) list
       

--- a/src/Html.hs
+++ b/src/Html.hs
@@ -8,6 +8,8 @@ module Html
   , txt_
   , html_
   , h1_
+  , h2_
+  , h3_
   , hr_
   , p_
   , ul_
@@ -58,6 +60,12 @@ p_ = Structure . el "p" . getContentString
 
 h1_ :: Content -> Structure
 h1_ = Structure . el "h1" . getContentString
+
+h2_ :: Content -> Structure
+h2_ = Structure . el "h2" . getContentString
+
+h3_ :: Content -> Structure
+h3_ = Structure . el "h3" . getContentString
 
 ul_ :: [Structure] -> Structure
 ul_ =

--- a/src/Markup.hs
+++ b/src/Markup.hs
@@ -27,14 +27,22 @@ parse = parseLines Nothing . lines
 parseLines :: Maybe Structure -> [String] -> Document
 parseLines context txts =
   case txts of
-    -- done case
+    -- * done case
     [] -> maybeToList context
 
-    -- Heading 1 case
+    -- * Heading 1 case
     ('*' : ' ' : line) : rest ->
       maybe id (:) context (Heading 1 (trim line) : parseLines Nothing rest)
-    
-    -- Unordered list case
+
+    -- * Heading 2 case
+    ('*' : '*' : ' ' : line) : rest ->
+      maybe id (:) context (Heading 2 (trim line) : parseLines Nothing rest)
+
+    -- * Heading 3 case
+    ('*' : '*' : '*' : ' ' : line) : rest ->
+      maybe id (:) context (Heading 3 (trim line) : parseLines Nothing rest)
+
+    -- * Unordered list case
     ('-' : ' ' : line) : rest ->
       case context of
         Just (UnorderedList list) ->
@@ -43,7 +51,7 @@ parseLines context txts =
         _ ->
           maybe id (:) context (parseLines (Just (UnorderedList [trim line])) rest)
     
-    -- Ordered list case
+    -- * Ordered list case
     ('#' : ' ' : line) : rest ->
       case context of
         Just (OrderedList list) ->
@@ -52,7 +60,7 @@ parseLines context txts =
         _ ->
           maybe id (:) context (parseLines (Just (OrderedList [trim line])) rest)
 
-    -- Code block case
+    -- * Code block case
     ('>' : ' ' : line) : rest ->
       case context of
         Just (CodeBlock code) ->
@@ -61,11 +69,11 @@ parseLines context txts =
         _ ->
           maybe id (:) context (parseLines (Just (CodeBlock [line])) rest)
     
-    -- Horizontal line case
-    ("---") : rest ->
+    -- * Horizontal line case
+    ('-' : '-' : '-' : line) : rest ->
       maybe id (:) context (HorizontalLine "_" : parseLines Nothing rest)
     
-    -- Paragraph case
+    -- * Paragraph case
     currentLine : rest ->
       let
         line = trim currentLine


### PR DESCRIPTION
This pull request introduces several enhancements to the HTML and Haskell source files, focusing on adding support for additional heading levels (H2 and H3) and updating the parsing and conversion logic accordingly. The most important changes include updates to the HTML structure, CSS styles, and Haskell parsing and conversion functions.

### Enhancements to HTML and CSS:

* [`Output/blog.html`](diffhunk://#diff-c6eebd6134faccb682229c887cbffa4cca5cf19c18afd2f3cacba15687f36ae7L34-R50): Added support for H2 and H3 tags in the HTML structure and updated the content accordingly.
* [`Styles/defaultStyles.css`](diffhunk://#diff-4fb1e21b0335e54468e368d377a5add0c052e502e2d0e8be1d564e572d669294R9-R24): Introduced new styles for H2 and H3 tags, including gradient text effects.

### Updates to Haskell Parsing and Conversion:

* [`src/Convert.hs`](diffhunk://#diff-f6934999e2d67ae7caa288a84b000af41d1067c517436f64d3b7f88f48595804R15-R20): Added conversion logic for H2 and H3 headings.
* [`src/Html.hs`](diffhunk://#diff-77f3e5af98b7457d91342dc79deeef1d36ea2a138debf829ad3a731bae95a687R64-R69): Defined new functions `h2_` and `h3_` for handling H2 and H3 headings.
* [`src/Markup.hs`](diffhunk://#diff-750d02566fc0dbe7c032fa4801406e7603870d00ab46dba091186c23306d7941L30-R45): Updated the `parseLines` function to handle new heading levels (H2 and H3) and revised comments for clarity. [[1]](diffhunk://#diff-750d02566fc0dbe7c032fa4801406e7603870d00ab46dba091186c23306d7941L30-R45) [[2]](diffhunk://#diff-750d02566fc0dbe7c032fa4801406e7603870d00ab46dba091186c23306d7941L46-R54) [[3]](diffhunk://#diff-750d02566fc0dbe7c032fa4801406e7603870d00ab46dba091186c23306d7941L55-R63) [[4]](diffhunk://#diff-750d02566fc0dbe7c032fa4801406e7603870d00ab46dba091186c23306d7941L64-R76)